### PR TITLE
0.1.0: Restart ESLint server when package install is successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "package-watcher" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.0]
+
+- Restart ESLint Server when package install is successful & [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) is installed
+
 ## [0.0.9]
 
 - Notifications bug fix

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Watch package lock files and suggest to re-run npm or yarn.
 
 - `npm` and `yarn` support
 - Monorepo support
-- 2 Modes: `notify` & `auto` [mode](#extension-settings)
+- 2 Modes: `auto` & `request` [mode](#extension-settings)
+- Restart ESLint server when package install is successful
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package-watcher",
   "displayName": "Package Watcher",
   "description": "Watch package lock files and run npm or yarn",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "publisher": "pinterest",
   "engines": {
     "vscode": "^1.53.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,6 +136,11 @@ class PackageWatcherExtension {
               `${command} in ${relativeDirectory} succeeded`
             );
           }
+
+          const commands = await vscode.commands.getCommands(true);
+          if (commands.includes("eslint.restart")) {
+            await vscode.commands.executeCommand("eslint.restart");
+          }
         } else {
           log.debug(`[Command Exit Code] ${exitCode}`);
           [


### PR DESCRIPTION
Makes it so that when you have the ESLint extension installed, it will automatically restart the ESLint server. We do this because sometimes ESLint says that it can't find a rule even though it's already installed.